### PR TITLE
Add OpenRouter For More AI Capabilities

### DIFF
--- a/app/src/components/Chat.tsx
+++ b/app/src/components/Chat.tsx
@@ -1,12 +1,14 @@
 import { SupabaseClient } from "@supabase/supabase-js";
 import { useEffect, useRef, useState } from "react";
 import ChatLog, { Message } from "./ChatLog";
+import ChatsHistory, { HistoryChat } from './chatsHistory';
 import LogoutButton from "./LogoutButton";
 import { Button } from "./ui/button";
-import { Plus } from "lucide-react";
+import { Plus, History } from "lucide-react";
 import { ThemeToggle } from "./ThemeToggle";
 import PromptForm from "./PromptForm";
 import { toast } from "sonner";
+import { Console } from "console";
 
 export default function Chat({
   supabaseClient,
@@ -18,8 +20,10 @@ export default function Chat({
 
   const [entryData, setEntryData] = useState("");
   const [messages, setMessages] = useState<Message[]>([]);
+  const [historyChats, setChatsList] = useState<HistoryChat[]>([]);
   const [chatId, setChatId] = useState<Message[]>([]);
   const [waitingForResponse, setWaitingForResponse] = useState(false);
+  const [showChatsHistory, setShowChatsHistory] = useState(false);
 
   const onSendMsgClick = async () => {
     try {
@@ -84,12 +88,14 @@ export default function Chat({
     }
   };
 
-  const fetchLastConversation = async () => {
+  const fetchLastConversation = async (chatId?: number) => {
+    console.log('chatId', chatId)
     try {
       const { data, error } = await supabaseClient
         .from("conversations")
         .select("*")
         .order("created_at", { ascending: false })
+        .filter("id", chatId ? "eq" : "not.eq", chatId ? chatId : 0)
         .limit(1);
 
       if (!data || data.length == 0 || error) {
@@ -127,14 +133,30 @@ export default function Chat({
         >
           <Plus size={20} />
         </Button>
+
+        <Button
+          size={"icon"}
+          className="rounded-full bg-muted/20 text-muted-foreground hover:bg-muted/40"
+          onClick={() => {
+            setShowChatsHistory(!showChatsHistory)
+          }}
+        >
+          <History size={20} />
+        </Button>
+
         <ThemeToggle />
       </div>
 
       <div className="p-8 mt-12 mb-32">
-        <ChatLog
-          messages={messages}
-          waitingForResponse={waitingForResponse}
-        />
+        {(
+          showChatsHistory ?
+            <ChatsHistory 
+              supabaseClient={supabaseClient} 
+              handleClose={() => { setShowChatsHistory(!showChatsHistory) }}
+              fetchLastConversation={(chatId) => { fetchLastConversation(chatId) }}
+            /> :
+            <ChatLog messages={messages} waitingForResponse={waitingForResponse} />
+        )}
       </div>
 
       <div ref={bottomRef} />

--- a/app/src/components/LoginForm.tsx
+++ b/app/src/components/LoginForm.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { Button } from "./ui/button";
 import { useEffect, useState } from "react";
 import { createClient } from "@supabase/supabase-js";
-import { useRouter } from "next/router";
+import { useRouter } from 'next/navigation';
 import { useSupabaseConfig } from "@/utils/useSupabaseConfig";
 import { toast } from "sonner";
 

--- a/app/src/components/chatsHistory.tsx
+++ b/app/src/components/chatsHistory.tsx
@@ -1,0 +1,100 @@
+import React, { useEffect, useState } from 'react';
+import { SupabaseClient } from "@supabase/supabase-js";
+import { Trash, ArrowRight } from "lucide-react";
+import { AnimatePresence, motion } from "framer-motion";
+import { Button } from "./ui/button";
+
+export interface HistoryChat {
+    id: number;
+    created_at: string;
+};
+
+export default function ChatsHistory({
+    supabaseClient,
+    handleClose,
+    fetchLastConversation,
+}: {
+    supabaseClient: SupabaseClient;
+    handleClose: () => void;
+    fetchLastConversation: (chatId: number) => void;
+}) {
+    const [listReceived, setListReceived] = useState(false);
+    const [chatsList, setChats] = useState<HistoryChat[]>([]);
+
+    const fetchChatsList = async () => {
+        try {
+            const { data, error } = await supabaseClient
+                .from("conversations")
+                .select("id, created_at")
+                .order("created_at", { ascending: false });
+            if (data) {
+                setChats(data);
+            }
+        } catch (error: any) {
+            console.error("ERROR", error);
+        }
+    };
+
+    const removeChat = async (chatId: number) => {
+        try {
+            const { data, error } = await supabaseClient
+                .from("conversations")
+                .delete()
+                .eq("id", chatId);
+            if (data) {
+                setChats(data);
+            }
+        } catch (error: any) {
+            console.error("ERROR", error);
+        }
+        await fetchChatsList();
+    }
+
+    useEffect(() => {
+        fetchChatsList();
+    }, []);
+
+    const formatDate = (dateString: string) => {
+        const date = new Date(dateString);
+        return `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+    };
+
+    return (
+        <div className="modal p-4 flex flex-col items-center justify-center">
+            <Button
+                onClick={() => handleClose()}
+                className="mb-6 bg-muted/20 hover:bg-muted/50  py-2 px-4"
+            >
+                Back to Chat
+            </Button>
+
+            <AnimatePresence initial={false}>
+                {chatsList.length > 0 ? (
+                    <div className="space-y-4">
+                        {chatsList.map((chat) => (
+                            <motion.div
+                                key={chat.id}
+                                className="card flex bg-muted/20 rounded-xl px-4 py-3 mb-2 shadow-sm"
+                                initial={{ opacity: 0 }}
+                                animate={{ opacity: 1 }}
+                                exit={{ opacity: 0 }}
+                            >
+                                <div className="flex flex-col justify-between">
+                                    <div>ID: {chat.id}</div>
+                                    <div className="text-sm text-gray-500">Created: {formatDate(chat.created_at)}</div>
+                                </div>
+                                <div className="flex flex-col justify-center items-center pl-10">
+                                    <ArrowRight size={20} onClick={() => {
+                                        fetchLastConversation(chat["id"]);
+                                        handleClose();
+                                    }}></ArrowRight>
+                                    <Trash className='mt-2' size={20} onClick={async () => { await removeChat(chat["id"]) }}></Trash>
+                                </div>
+                            </motion.div>
+                        ))}
+                    </div>
+                ) : listReceived ? <span>You don't have chats.</span> : <span>Loading...</span>}
+            </AnimatePresence>
+        </div>
+    );
+};

--- a/app/src/components/chatsHistory.tsx
+++ b/app/src/components/chatsHistory.tsx
@@ -93,7 +93,7 @@ export default function ChatsHistory({
                             </motion.div>
                         ))}
                     </div>
-                ) : listReceived ? <span>You don't have chats.</span> : <span>Loading...</span>}
+                ) : listReceived ? <span>You dont have chats.</span> : <span>Loading...</span>}
             </AnimatePresence>
         </div>
     );


### PR DESCRIPTION
This PR adds OpenRouter as an additional provider of open and close source AI models. This way users are able to access way more AI models while they are building with ADeus. 😄 

What was changed 

- Updated the Supabase 'Chat' Edge Function to handle requests for OpenRouter (and refactored so OpenAI was still easy to route to)
- Updated the front end to include a toggle for using OpenRouter as well as a select box for so users can choose their own models
- Created new select and switch components in the UI folder
- Updated the docs to include OpenRouter Setup
- Updated with most recent commits to code (Chat History)

If you have any questions or comments please let me know!